### PR TITLE
add metadata field

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -41,6 +41,7 @@ type Subscription struct {
 	Options                 *SubscriptionOptions `xml:"options,omitempty"`
 	// AddOns                  []interface{} `xml:"add-ons,omitempty"`
 	// Descriptor              interface{}   `xml:"descriptor,omitempty"`   // struct with name, phone
+	Metadata string `xml:"metadata"`
 }
 
 type Subscriptions struct {

--- a/transaction.go
+++ b/transaction.go
@@ -33,6 +33,7 @@ type Transaction struct {
 	Type                  string               `xml:"type,omitempty"`
 	UpdatedAt             *time.Time           `xml:"updated-at,omitempty"`
 	XMLName               string               `xml:"transaction"`
+	Metadata              string               `xml:"metadata"`
 }
 
 type SubscriptionDetails struct {


### PR DESCRIPTION
re. Braintree custom fields: https://articles.braintreepayments.com/control-panel/custom-fields

Braintree allows custom fields for their API; I added `metadata` as the name of a new custom field in the control panel and now we need a way to write to it.